### PR TITLE
Updating Liberty API/SPI targets for 16.0.0.2 release

### DIFF
--- a/targets/liberty-apis/pom.xml
+++ b/targets/liberty-apis/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
-    <version>8.5.5.9</version>
+    <version>16.0.0.2</version>
     <artifactId>targets-parent</artifactId>
   </parent>
 
@@ -19,228 +19,234 @@
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.basics</artifactId>
-      <version>1.2.12</version>
+      <version>1.2.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.clusterMember</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.collectiveController</artifactId>
-      <version>1.5.12</version>
+      <version>1.5.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.config</artifactId>
-      <version>1.2.12</version>
+      <version>1.2.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.connectionpool</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.constrainedDelegation</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.distributedMap</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.dynamicRouting</artifactId>
-      <version>1.0.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.ejbcontainer</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.endpoint</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.hpel</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.j2eemanagement</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.jaxrs</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.json</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.kernel.service</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.messaging</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.monitor</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.oauth</artifactId>
-      <version>1.2.12</version>
+      <version>1.2.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.oidc</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.persistence</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.restConnector</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.saml20</artifactId>
-      <version>1.0.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.scalingController</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.scalingMember</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security</artifactId>
-      <version>1.2.12</version>
+      <version>1.2.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security.authorization.saf</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security.registry.saf</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.securityClient</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.servlet</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sessionstats</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sipServlet.1.1</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sipServletSecurity.1.0</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.transaction</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.webCache</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.webcontainer.security.app</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.wsoc</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.zosLocalAdapters</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.zosRequestLogging</artifactId>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
   </dependencies>

--- a/targets/liberty-spis/pom.xml
+++ b/targets/liberty-spis/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
-    <version>8.5.5.9</version>
+    <version>16.0.0.2</version>
     <artifactId>targets-parent</artifactId>
   </parent>
 
@@ -19,163 +19,163 @@
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.anno</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.application</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.artifact</artifactId>
-      <version>1.2.12</version>
+      <version>1.2.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.classloading</artifactId>
-      <version>1.2.12</version>
+      <version>1.2.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.collectiveMember</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.containerServices</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.globalhandler</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.httptransport</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.javaeedd</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.jsp</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.embeddable</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.filemonitor</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.metatype</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.service</artifactId>
-      <version>1.4.12</version>
+      <version>1.4.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.logging</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.oauth</artifactId>
-      <version>1.1.12</version>
+      <version>1.2.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.restHandler</artifactId>
-      <version>1.4.12</version>
+      <version>1.4.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.saml20</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.scalingController</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.servlet</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.ssl</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.threading</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.timedOperations</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.transaction</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.webCache</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.wsat</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.zosConnect</artifactId>
-      <version>1.0.12</version>
+      <version>1.0.13</version>
       <type>jar</type>
     </dependency>
   </dependencies>

--- a/targets/liberty-target/pom.xml
+++ b/targets/liberty-target/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
-    <version>8.5.5.9</version>
+    <version>16.0.0.2</version>
     <artifactId>targets-parent</artifactId>
   </parent>
 

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>targets-parent</artifactId>
-  <version>8.5.5.9</version>
+  <version>16.0.0.2</version>
   <packaging>pom</packaging>
 
   <name>WebSphere Liberty dependencies parent POM</name>


### PR DESCRIPTION
Updated the pom.xml files in the target folders to incorporate the liberty API/SPI changes for the 16.0.0.2 release.