### PR TITLE
Update websphere liberty runtime targets to use 16.0.0.3 API/SPI jars.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,23 @@
   </distributionManagement>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.6</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+	
     <pluginManagement>
       <plugins>
         <plugin>
@@ -66,6 +83,29 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.3</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+		
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -92,6 +132,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-archetype-plugin</artifactId>
           <version>2.4</version>
+		  <dependencies>
+		    <dependency>
+              <groupId>org.apache.maven.shared</groupId>
+              <artifactId>maven-invoker</artifactId>
+              <version>2.2</version>
+			</dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/targets/liberty-apis/pom.xml
+++ b/targets/liberty-apis/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
-    <version>16.0.0.2</version>
+    <version>16.0.0.3</version>
     <artifactId>targets-parent</artifactId>
   </parent>
 
@@ -18,235 +18,253 @@
   <dependencies>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.authData</artifactId>
+      <version>1.0.14</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.basics</artifactId>
-      <version>1.2.13</version>
+      <version>1.2.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.clusterMember</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.collectiveController</artifactId>
-      <version>1.5.13</version>
+      <version>1.5.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.config</artifactId>
-      <version>1.2.13</version>
+      <version>1.2.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.connectionpool</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.constrainedDelegation</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.distributedMap</artifactId>
-      <version>2.0.13</version>
+      <version>2.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.dynamicRouting</artifactId>
-      <version>1.1.13</version>
+      <version>1.2.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.ejbcontainer</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.endpoint</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.hpel</artifactId>
-      <version>2.0.13</version>
+      <version>2.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.j2eemanagement</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.jacc</artifactId>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.jaxrs</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.json</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.kernel.service</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.messaging</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.monitor</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.oauth</artifactId>
-      <version>1.2.13</version>
+      <version>1.2.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.oidc</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.persistence</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.restConnector</artifactId>
-      <version>1.1.13</version>
+      <version>1.2.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.saml20</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.scalingController</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.scalingMember</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security</artifactId>
-      <version>1.2.13</version>
+      <version>1.2.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security.authorization.saf</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security.registry.saf</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.securityClient</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.servlet</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sessionstats</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sipServlet.1.1</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sipServletSecurity.1.0</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.ssl</artifactId>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.transaction</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.webCache</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.webcontainer.security.app</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.wsoc</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.zosLocalAdapters</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.zosRequestLogging</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
   </dependencies>

--- a/targets/liberty-spis/pom.xml
+++ b/targets/liberty-spis/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
-    <version>16.0.0.2</version>
+    <version>16.0.0.3</version>
     <artifactId>targets-parent</artifactId>
   </parent>
 
@@ -19,163 +19,181 @@
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.anno</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.application</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.artifact</artifactId>
-      <version>1.2.13</version>
+      <version>1.2.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.classloading</artifactId>
-      <version>1.2.13</version>
+      <version>1.2.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.collectiveMember</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.containerServices</artifactId>
-      <version>2.0.13</version>
+      <version>2.0.14</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.spi</groupId>
+      <artifactId>com.ibm.websphere.appserver.spi.federatedRepository</artifactId>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.globalhandler</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.httptransport</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.spi</groupId>
+      <artifactId>com.ibm.websphere.appserver.spi.jaspic</artifactId>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.javaeedd</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.jsp</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.embeddable</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.filemonitor</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.metatype</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.service</artifactId>
-      <version>1.4.13</version>
+      <version>1.5.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.logging</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.oauth</artifactId>
-      <version>1.2.13</version>
+      <version>1.4.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.restHandler</artifactId>
-      <version>1.4.13</version>
+      <version>1.5.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.saml20</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.scalingController</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.servlet</artifactId>
-      <version>2.0.13</version>
+      <version>2.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.ssl</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.threading</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.timedOperations</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.transaction</artifactId>
-      <version>1.1.13</version>
+      <version>1.1.14</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.spi</groupId>
+      <artifactId>com.ibm.websphere.appserver.spi.wab.configure</artifactId>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.webCache</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.wsat</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.zosConnect</artifactId>
-      <version>1.0.13</version>
+      <version>1.0.14</version>
       <type>jar</type>
     </dependency>
   </dependencies>

--- a/targets/liberty-target/pom.xml
+++ b/targets/liberty-target/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
-    <version>16.0.0.2</version>
+    <version>16.0.0.3</version>
     <artifactId>targets-parent</artifactId>
   </parent>
 

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>targets-parent</artifactId>
-  <version>16.0.0.2</version>
+  <version>16.0.0.3</version>
   <packaging>pom</packaging>
 
   <name>WebSphere Liberty dependencies parent POM</name>


### PR DESCRIPTION
The maven-gpg-plugin and maven-javadoc-plugin changes simplify the deployment to the staging server.  

The maven-invoker dependency is needed due to issue https://issues.apache.org/jira/browse/ARCHETYPE-488

With these changes the deployment to the staging server is simply a "mvn clean deploy" away. :)