### PR TITLE
Add space after markdown header hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ci.maven.tools
 
 ci.maven.tools is a collection of Maven archetypes and target POMs for developing Java EE and OSGi applications targeting WebSphere Application Server Liberty within the WDT Eclipse IDE.
 
-##Projects
+## Projects
 
 There are provided two different projects to be used in Maven environments: [Maven Target POMs](#maven-target-poms), a set of convenience POMs that groups WebSphere Liberty dependencies; and [Maven archetypes](#archetypes), to create new Maven projects with recommended configurations and dependencies targeting WebSphere Liberty.
 
@@ -43,7 +43,7 @@ osgi-web25-liberty		| OSGi Web 2.5 project
 osgi-web30-liberty		| OSGi Web 3.0 project
 osgi-web31-liberty		| OSGi Web 3.1 project
 
-##How to build
+## How to build
 
 To build and install the whole project in your local Maven repository, locate in the root folder and then execute one of the following commands in a Maven terminal.
 

--- a/docs/archetypes.md
+++ b/docs/archetypes.md
@@ -5,7 +5,7 @@ This multi-module project contains archetypes to develop new Maven Java EE and O
 
 *Note: Usage of following archetypes is recommended with WAS Developer Tools (WDT) for Eclipse IDE.*
 
-##Project structure
+## Project structure
 
 	archetypes/ - Parent POM to build all archetypes
 		pom.xml 
@@ -30,7 +30,7 @@ This multi-module project contains archetypes to develop new Maven Java EE and O
 		webapp-jee7-liberty/ - Web 3.1 archetype
 			pom.xml
 
-##Archetypes list
+## Archetypes list
 
 Following is the list of provided archetypes. The Archetypes groupId is `net.wasdev.maven.tools.archetypes` 
 
@@ -54,11 +54,11 @@ osgi-web25-liberty		| OSGi Web 2.5 project
 osgi-web30-liberty		| OSGi Web 3.0 project
 osgi-web31-liberty		| OSGi Web 3.1 project
 
-##Usage information
+## Usage information
 
 You can use the provided archetypes by using WDT for Eclipse IDE and by CLI.
 
-###Usage with WDT for Eclipse IDE
+### Usage with WDT for Eclipse IDE
 
 1. Open the New Project Wizard by selecting **File/New/Other...** menu.
 2. In the Filter textbox type **Maven Project** and press **Next** button.
@@ -67,7 +67,7 @@ You can use the provided archetypes by using WDT for Eclipse IDE and by CLI.
 5. Select one of the provided archetypes and then follow the Wizard.
 6. Once completed, wait until all processes conclude and WDT for Eclipse IDE will install project facets and configure your Maven project in base of the archetype you chose at step 5.
 
-###Usage by CLI
+### Usage by CLI
 
 Open a Maven terminal and then execute following command to generate a new Maven project:
 
@@ -75,7 +75,7 @@ Open a Maven terminal and then execute following command to generate a new Maven
 
 After executing the command the interactive mode will be asked for some values like your artifactId, groupId and version for your project before finishing.
 
-##How to build
+## How to build
 
 *Before building this project in your machine, ensure you have installed the [target POMs project](../docs/target-poms.md) as archetypes use net.wasdev.maven.tools.targets:liberty-target:RELEASE dependency*.
 

--- a/docs/target-poms.md
+++ b/docs/target-poms.md
@@ -26,13 +26,13 @@ Dependencies are grouped in following modules:
 		third-party/ - Third-party dependencies module
 			pom.xml
 
-##Usage information
+## Usage information
 
 Following modules add WebSphere Liberty dependencies to your project. Add the dependency snippet to your Maven project to reference all dependencies automatically.
 
 It's important to notice that the version of the `liberty-target`, `liberty-apis` and `liberty-spis` are aligned to the release of WebSphere Liberty, so you can use older versions by changing the version of those artifacts.
 
-###liberty-target
+### liberty-target
 
 This project aggregates all other modules that references WebSphere Liberty APIs/SPIs, java specifications and third-party implementations dependencies to compile your project.
 
@@ -46,7 +46,7 @@ Dependency snippet:
 		<scope>provided</scope>
 	</dependency>
 	
-###liberty-apis
+### liberty-apis
 
 WebSphere Liberty API's dependencies. This POM satisfies all APIs libraries that a Liberty installation provides in the `dev/api/ibm` folder.
 
@@ -60,7 +60,7 @@ Dependency snippet:
 		<scope>provided</scope>
 	</dependency>
 
-###liberty-spis
+### liberty-spis
 
 WebSphere Liberty SPI's dependencies. This POM satisfies all SPIs libraries that a Liberty installation provides in the `dev/spi/ibm` folder.
 
@@ -74,7 +74,7 @@ Dependency snippet:
 		<scope>provided</scope>
 	</dependency>
 
-###java-specs
+### java-specs
 
 Java specification dependencies. This POM satisfies all Java specification libraries that a Liberty installation provides in the `dev/api/spec` and `dev/spi/spec` folders.
 
@@ -89,7 +89,7 @@ Dependency snippet:
 	</dependency>
 
 
-###third-party
+### third-party
 
 Third-party implementation dependencies. This POM satisfies all third-party libraries that a Liberty installation provides in the `dev/api/third-party` and `dev/spi/third-party` folders.
 
@@ -103,7 +103,7 @@ Dependency snippet:
 		<scope>provided</scope>
 	</dependency>
 
-##How to build
+## How to build
 
 To build the whole target POMs project locate in the `targets/` folder and execute following command in a Maven terminal:
 


### PR DESCRIPTION
I noticed that the github documentation pages were not rendering some section headings correctly due to the hashes not having a space between them and the heading title. This PR is a small fix which just adds some spaces where they were missing.