### PR TITLE
Update target poms for 17.0.0.2

### DIFF
--- a/targets/liberty-apis/pom.xml
+++ b/targets/liberty-apis/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
     <artifactId>targets-parent</artifactId>
-    <version>17.0.0.1</version>
+    <version>17.0.0.2</version>
   </parent>
   <groupId>net.wasdev.maven.tools.targets</groupId>
   <artifactId>liberty-apis</artifactId>
-  <version>17.0.0.1</version>
+  <version>17.0.0.2</version>
   <packaging>pom</packaging>
   <name>WebSphere Liberty API libraries</name>
   <description>POM targeting WebSphere Liberty API libraries</description>
@@ -17,217 +17,222 @@
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.authData</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.basics</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.clusterMember</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.collectiveController</artifactId>
-      <version>1.5.16</version>
+      <version>1.5.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.config</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.connectionpool</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.constrainedDelegation</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.distributedMap</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.dynamicRouting</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.ejbcontainer</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.endpoint</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.hpel</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.j2eemanagement</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.jacc</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.jaxrs</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.json</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.jwt</artifactId>
-      <version>1.0.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.kernel.service</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.messaging</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.monitor</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.oauth</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.oidc</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.persistence</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.restConnector</artifactId>
-      <version>1.2.16</version>
+      <version>1.3.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.saml20</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.scalingController</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.scalingMember</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security.authorization.saf</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.securityClient</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.security.registry.saf</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.servlet</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sessionstats</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sipServlet.1.1</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.sipServletSecurity.1.0</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.social</artifactId>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.ssl</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.transaction</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.webCache</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.webcontainer.security.app</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.wsoc</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.zosLocalAdapters</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.api</groupId>
       <artifactId>com.ibm.websphere.appserver.api.zosRequestLogging</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
   </dependencies>
 </project>

--- a/targets/liberty-spis/pom.xml
+++ b/targets/liberty-spis/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
     <artifactId>targets-parent</artifactId>
-    <version>17.0.0.1</version>
+    <version>17.0.0.2</version>
   </parent>
   <groupId>net.wasdev.maven.tools.targets</groupId>
   <artifactId>liberty-spis</artifactId>
-  <version>17.0.0.1</version>
+  <version>17.0.0.2</version>
   <packaging>pom</packaging>
   <name>WebSphere Liberty SPI libraries</name>
   <description>POM targeting WebSphere Liberty SPI libraries</description>
@@ -17,157 +17,172 @@
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.anno</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.application</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.artifact</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.classloading</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.collectiveMember</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.spi</groupId>
+      <artifactId>com.ibm.websphere.appserver.spi.collectivePlugins</artifactId>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.containerServices</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.federatedRepository</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.globalhandler</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.httptransport</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.jaspic</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.javaeedd</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.jsp</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.embeddable</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.filemonitor</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.metatype</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.kernel.service</artifactId>
-      <version>1.5.16</version>
+      <version>1.5.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.logging</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.oauth</artifactId>
-      <version>1.4.16</version>
+      <version>1.4.17</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.spi</groupId>
+      <artifactId>com.ibm.websphere.appserver.spi.productInsights</artifactId>
+      <version>1.0.17</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.spi</groupId>
+      <artifactId>com.ibm.websphere.appserver.spi.restAPIDiscovery</artifactId>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.restHandler</artifactId>
-      <version>1.5.16</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.saml20</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.scalingController</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.servlet</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.ssl</artifactId>
-      <version>1.1.16</version>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.threading</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.timedOperations</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.transaction</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.wab.configure</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.webCache</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.wsat</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
-      <artifactId>com.ibm.websphere.appserver.spi.zos.command.processing</artifactId>
-      <version>1.0.16</version>
+      <artifactId>com.ibm.websphere.appserver.spi.zosCommandProcessing</artifactId>
+      <version>1.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.websphere.appserver.spi</groupId>
       <artifactId>com.ibm.websphere.appserver.spi.zosConnect</artifactId>
-      <version>1.0.16</version>
+      <version>1.0.17</version>
     </dependency>
   </dependencies>
 </project>

--- a/targets/liberty-target/pom.xml
+++ b/targets/liberty-target/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>net.wasdev.maven.tools.parents</groupId>
-    <version>17.0.0.1</version>
+    <version>17.0.0.2</version>
     <artifactId>targets-parent</artifactId>
   </parent>
 

--- a/targets/pom.xml
+++ b/targets/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>targets-parent</artifactId>
-  <version>17.0.0.1</version>
+  <version>17.0.0.2</version>
   <packaging>pom</packaging>
 
   <name>WebSphere Liberty dependencies parent POM</name>


### PR DESCRIPTION
PR for issue #21
Release new versions of target POMs supporting WebSphere Liberty 17.0.0.2 APis/SPIs.